### PR TITLE
docs: add CLAUDE.md project pointer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+## Project Location
+**Local**: `/Users/claw2501/modular-wall` (⚠️ duplicate also at `/Volumes/Extreme Pro/ACTIVE/modular-wall`)
+**GitHub**: https://github.com/igwana12/modular-wall
+**Port**: none · **Stack**: Node + Python · **Status**: REPO
+
+AI-orchestrated snap-together mixed-media wall computer — docs/planning only, no server.
+Canonical is `~/modular-wall`; EP copy is a dup (pending resolution).


### PR DESCRIPTION
## Summary
- Adds a `CLAUDE.md` at the repo root so future Claude Code sessions opening this repo get immediate context (project location, GitHub remote, stack, duplicate situation) without having to re-discover.

## Notes for reviewer
- Single new file, 7 lines.
- Documents the canonical-vs-`/Volumes/Extreme Pro/ACTIVE/modular-wall` duplicate (the EP copy is still pending resolution).
- No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)